### PR TITLE
Fixed bug that stops Google Sheets API being able to authenticate

### DIFF
--- a/java/src/com/google/gdata/client/http/GoogleGDataRequest.java
+++ b/java/src/com/google/gdata/client/http/GoogleGDataRequest.java
@@ -196,6 +196,10 @@ public class GoogleGDataRequest extends HttpGDataRequest {
      */
     private boolean matchDomain(String testDomain, String tailDomain) {
 
+      if (tailDomain.startsWith(".")) {
+    	  tailDomain= tailDomain.substring(1);
+      }
+    	
       // Simple check
       if (!testDomain.endsWith(tailDomain)) {
         return false;


### PR DESCRIPTION
I'm having to patch this in my own code currently. Without this, matchDomain fails on a valid subdomain cookie whose domain starts with ".".