### PR TITLE
Bug: UTF-32-LE misdetected as UTF-16-LE

### DIFF
--- a/java/src/com/google/gdata/util/io/base/UnicodeReader.java
+++ b/java/src/com/google/gdata/util/io/base/UnicodeReader.java
@@ -60,20 +60,20 @@ public class UnicodeReader extends Reader {
         && (bom[2] == (byte) 0xBF)) {
       encoding = "UTF-8";
       unread = n - 3;
+    } else if ((bom[0] == (byte) 0x00) && (bom[1] == (byte) 0x00)
+            && (bom[2] == (byte) 0xFE) && (bom[3] == (byte) 0xFF)) {
+      encoding = "UTF-32BE";
+      unread = n - 4;
+    } else if ((bom[0] == (byte) 0xFF) && (bom[1] == (byte) 0xFE)
+            && (bom[2] == (byte) 0x00) && (bom[3] == (byte) 0x00)) {
+      encoding = "UTF-32LE";
+      unread = n - 4;
     } else if ((bom[0] == (byte) 0xFE) && (bom[1] == (byte) 0xFF)) {
       encoding = "UTF-16BE";
       unread = n - 2;
     } else if ((bom[0] == (byte) 0xFF) && (bom[1] == (byte) 0xFE)) {
       encoding = "UTF-16LE";
       unread = n - 2;
-    } else if ((bom[0] == (byte) 0x00) && (bom[1] == (byte) 0x00)
-        && (bom[2] == (byte) 0xFE) && (bom[3] == (byte) 0xFF)) {
-      encoding = "UTF-32BE";
-      unread = n - 4;
-    } else if ((bom[0] == (byte) 0xFF) && (bom[1] == (byte) 0xFE)
-        && (bom[2] == (byte) 0x00) && (bom[3] == (byte) 0x00)) {
-      encoding = "UTF-32LE";
-      unread = n - 4;
     } else {
       // Unicode BOM mark not found, unread all bytes
       encoding = defaultEnc;


### PR DESCRIPTION
Problem: the byte-order mark detector selects the the UTF-16-LE
encoding if the first two bytes of the stream are OxFF OxFE, without
checking to see if the next two bytes are null (which is the BOM for
UTF-32-LE).

Solution: check for the UTF-32 BOMs before checking for the UTF-16
marks.

Resolves #471 